### PR TITLE
A02: Move secrets to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Copy to `.env` and fill in. Never commit `.env`.
+
+# Flask
+FLASK_ENV=development
+FLASK_SECRET_KEY=replace_me_with_python_-c_import_secrets_secrets.token_hex_32
+
+# Database (overrides config/Connection.yaml when set)
+DB_SERVER=192.168.0.30
+DB_PORT=1433
+DB_NAME=First_Fault
+DB_USERNAME=
+DB_PASSWORD=
+DB_DRIVER=ODBC Driver 18 for SQL Server
+DB_ENCRYPT=true
+DB_TRUST_SERVER_CERT=false
+
+# SMTP (used by business/utils/mail_service.py)
+SMTP_HOST=
+SMTP_PORT=25
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_USE_TLS=false
+SMTP_USE_SSL=false
+SMTP_SENDER_EMAIL=

--- a/business/utils/mail_service.py
+++ b/business/utils/mail_service.py
@@ -166,12 +166,16 @@ class MailService:
 
 
 if __name__ == "__main__":
+    import os
+
     cfg = SmtpConfig(
-        host="192.168.0.174",
-        port=25,
-        username="benoit",
-        password="R@nger&1401!",
-        sender_email="benoit@albatros.be",
+        host=os.environ["SMTP_HOST"],
+        port=int(os.environ.get("SMTP_PORT", "25")),
+        username=os.environ.get("SMTP_USERNAME"),
+        password=os.environ.get("SMTP_PASSWORD"),
+        use_tls=os.environ.get("SMTP_USE_TLS", "false").lower() in ("1", "true", "yes"),
+        use_ssl=os.environ.get("SMTP_USE_SSL", "false").lower() in ("1", "true", "yes"),
+        sender_email=os.environ.get("SMTP_SENDER_EMAIL"),
     )
     ms = MailService(cfg)
     start_dt = datetime.now() + timedelta(days=1)

--- a/config/Connection.yaml.example
+++ b/config/Connection.yaml.example
@@ -1,0 +1,9 @@
+DBconnection:
+  server: 192.168.0.30
+  port: 1433
+  database: First_Fault
+  username: REPLACE_ME
+  password: REPLACE_ME
+  driver: ODBC Driver 18 for SQL Server
+  encrypt: true
+  trust_server_certificate: false

--- a/data/repositories/DB_Connection.py
+++ b/data/repositories/DB_Connection.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from contextlib import contextmanager
 from urllib.parse import quote_plus
@@ -25,19 +26,57 @@ class Base(DeclarativeBase):
 # ============================================================================
 # Configuration Loader
 # ============================================================================
+_ENV_OVERRIDES = {
+    "server": "DB_SERVER",
+    "port": "DB_PORT",
+    "database": "DB_NAME",
+    "username": "DB_USERNAME",
+    "password": "DB_PASSWORD",
+    "driver": "DB_DRIVER",
+    "encrypt": "DB_ENCRYPT",
+    "trust_server_certificate": "DB_TRUST_SERVER_CERT",
+}
+
+
+def _coerce(key: str, value: str):
+    if key == "port":
+        return int(value)
+    if key in ("encrypt", "trust_server_certificate"):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return value
+
+
 def load_db_config(config_path: Path | None = None) -> dict:
-    """Load database configuration from YAML file."""
+    """Load database configuration.
+
+    Resolution order per field: environment variable → YAML file → KeyError.
+    Credentials should be supplied via env vars in production; the YAML file
+    is convenient for local development only.
+    """
     path = config_path or CONFIG_PATH
-    try:
-        with open(path, "r") as file:
-            config = yaml.safe_load(file)
-        return config["DBconnection"]
-    except FileNotFoundError:
-        logger.error("Database config not found: %s", path)
-        raise
-    except (yaml.YAMLError, KeyError, TypeError) as e:
-        logger.error("Invalid database config in %s: %s", path, e)
-        raise
+    config: dict = {}
+    if path.exists():
+        try:
+            with open(path, "r") as file:
+                loaded = yaml.safe_load(file) or {}
+            config = loaded.get("DBconnection", {}) or {}
+        except (yaml.YAMLError, TypeError) as e:
+            logger.error("Invalid database config in %s: %s", path, e)
+            raise
+
+    for key, env_name in _ENV_OVERRIDES.items():
+        env_val = os.environ.get(env_name)
+        if env_val is not None and env_val != "":
+            config[key] = _coerce(key, env_val)
+
+    missing = [k for k in ("server", "database", "username", "password", "driver") if not config.get(k)]
+    if missing:
+        raise KeyError(
+            f"Missing required DB config keys: {missing}. "
+            f"Set via env ({', '.join(_ENV_OVERRIDES[k] for k in missing)}) "
+            f"or {path}."
+        )
+    return config
 
 
 # ============================================================================
@@ -51,8 +90,8 @@ def _build_odbc_connect_string(conn_config: dict) -> str:
         f"DATABASE={conn_config['database']}",
         f"UID={conn_config['username']}",
         f"PWD={conn_config['password']}",
-        f"Encrypt={'yes' if conn_config.get('encrypt', False) else 'no'}",
-        f"TrustServerCertificate={'yes' if conn_config.get('trust_server_certificate', True) else 'no'}",
+        f"Encrypt={'yes' if conn_config.get('encrypt', True) else 'no'}",
+        f"TrustServerCertificate={'yes' if conn_config.get('trust_server_certificate', False) else 'no'}",
         "MARS_Connection=yes",
     ]
     return ";".join(parts)

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -2,14 +2,12 @@ import logging
 import tomllib
 from pathlib import Path
 
-from flask import Flask, render_template, url_for, redirect, session
+from flask import Flask, render_template, url_for, redirect
 
 from config.logging_config import setup_logging
-from presentations.routes import plc_routes
-from presentations.services.creadential import Role
-from presentations.services.credential_service import CredentialService
+from presentations.routes import auth_routes, plc_routes
+from presentations.services.auth import current_user, login_required
 
-_auth_log = logging.getLogger("auth")
 _app_log = logging.getLogger("presentations")
 
 
@@ -19,6 +17,11 @@ def create_app() -> Flask:
     app = Flask("app")
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
+
+    # Gate every plc.* route behind authentication. Auth blueprint stays public.
+    plc_routes.bp.before_request(login_required(lambda: None))
+
+    app.register_blueprint(auth_routes.bp)
     app.register_blueprint(plc_routes.bp)
 
     config_path = (Path(__file__).resolve().parent.parent / "config" / "config.toml")
@@ -37,16 +40,9 @@ def create_app() -> Flask:
     app.config["SERVER_HOST"] = server_cfg.get("host", "127.0.0.1")
     app.config["SERVER_PORT"] = server_cfg.get("port", 5000)
 
-    @app.before_request
-    def ensure_session_credentials():
-        cred = CredentialService.get_current_credential()
-        if cred is not None:
-            is_new_session = "username" not in session
-            session["username"] = cred.username
-            role_obj = cred.role
-            session["role"] = role_obj.value if role_obj is not None else Role.GUEST.value
-            if is_new_session:
-                _auth_log.info("Session started: user=%s role=%s", cred.username, session["role"])
+    @app.context_processor
+    def inject_user():
+        return {"current_user": current_user()}
 
     @app.errorhandler(404)
     def not_found(e):

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import secrets
 import tomllib
 from pathlib import Path
 
@@ -17,7 +19,16 @@ def create_app() -> Flask:
     setup_logging()
 
     app = Flask("app")
-    app.secret_key = "dev"
+    secret_key = os.environ.get("FLASK_SECRET_KEY")
+    if not secret_key:
+        if os.environ.get("FLASK_ENV") == "production":
+            raise RuntimeError(
+                "FLASK_SECRET_KEY must be set in production. "
+                "Generate one with: python -c 'import secrets; print(secrets.token_hex(32))'"
+            )
+        secret_key = secrets.token_hex(32)
+        _app_log.warning("FLASK_SECRET_KEY not set; generated an ephemeral key for this process only")
+    app.secret_key = secret_key
     app.jinja_options["autoescape"] = True
     app.register_blueprint(plc_routes.bp)
 

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -1,8 +1,9 @@
 import logging
+import os
 import tomllib
 from pathlib import Path
 
-from flask import Flask, render_template, url_for, redirect
+from flask import Flask, render_template, url_for, redirect, session
 
 from config.logging_config import setup_logging
 from presentations.routes import auth_routes, plc_routes
@@ -14,7 +15,7 @@ _app_log = logging.getLogger("presentations")
 def create_app() -> Flask:
     setup_logging()
 
-    app = Flask("app")
+    app = Flask(__name__)
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
 
@@ -39,6 +40,13 @@ def create_app() -> Flask:
     server_cfg = loaded.get("server", {})
     app.config["SERVER_HOST"] = server_cfg.get("host", "127.0.0.1")
     app.config["SERVER_PORT"] = server_cfg.get("port", 5000)
+
+    def _csrf_token() -> str:
+        if "_csrf_token" not in session:
+            session["_csrf_token"] = os.urandom(32).hex()
+        return session["_csrf_token"]
+
+    app.jinja_env.globals["csrf_token"] = _csrf_token
 
     @app.context_processor
     def inject_user():

--- a/presentations/routes/auth_routes.py
+++ b/presentations/routes/auth_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
 
 from presentations.services.auth import (
     authenticate,
@@ -13,6 +13,10 @@ bp = Blueprint("auth", __name__, url_prefix="/auth")
 @bp.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":
+        submitted = request.form.get("csrf_token", "")
+        expected = session.get("_csrf_token", "")
+        if not submitted or submitted != expected:
+            abort(400)
         username = request.form.get("username", "").strip()
         password = request.form.get("password", "")
         user = authenticate(username, password)

--- a/presentations/routes/auth_routes.py
+++ b/presentations/routes/auth_routes.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+from presentations.services.auth import (
+    authenticate,
+    log_failed_login,
+    login_user,
+    logout_user,
+)
+
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+        user = authenticate(username, password)
+        if user is None:
+            log_failed_login(username)
+            flash("Invalid username or password.", "error")
+            return render_template("login.html", title="Login"), 401
+        login_user(user)
+        next_url = request.args.get("next") or url_for("plc.home")
+        if not next_url.startswith("/"):
+            next_url = url_for("plc.home")
+        return redirect(next_url)
+
+    return render_template("login.html", title="Login")
+
+
+@bp.route("/logout", methods=["POST"])
+def logout():
+    logout_user()
+    return redirect(url_for("auth.login"))

--- a/presentations/services/auth.py
+++ b/presentations/services/auth.py
@@ -1,0 +1,163 @@
+"""Authentication and authorization helpers.
+
+Replaces the previous stub `CredentialService` that returned an admin user
+unconditionally. This module:
+
+  * loads a user store from env vars (`AUTH_USERS_JSON`) or a JSON file
+    pointed to by `AUTH_USERS_FILE`
+  * verifies passwords with werkzeug.security
+  * exposes `login_required` and `role_required` decorators that emit
+    structured `AUTHZ_DENY` security events when access is refused
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from functools import wraps
+from pathlib import Path
+from typing import Iterable
+
+from flask import abort, redirect, request, session, url_for
+from werkzeug.security import check_password_hash
+
+from presentations.services.creadential import Role
+
+_auth_log = logging.getLogger("auth")
+_sec_log = logging.getLogger("security")
+
+
+@dataclass(frozen=True)
+class StoredUser:
+    username: str
+    password_hash: str
+    role: Role
+
+
+def _parse_users(raw: dict) -> dict[str, StoredUser]:
+    out: dict[str, StoredUser] = {}
+    for username, entry in raw.items():
+        try:
+            role = Role(entry.get("role", "user"))
+        except ValueError:
+            role = Role.GUEST
+        out[username] = StoredUser(
+            username=username,
+            password_hash=entry["password_hash"],
+            role=role,
+        )
+    return out
+
+
+def _load_user_store() -> dict[str, StoredUser]:
+    raw_json = os.environ.get("AUTH_USERS_JSON")
+    if raw_json:
+        return _parse_users(json.loads(raw_json))
+
+    file_path = os.environ.get("AUTH_USERS_FILE")
+    if file_path and Path(file_path).exists():
+        with open(file_path, "r", encoding="utf-8") as f:
+            return _parse_users(json.load(f))
+
+    return {}
+
+
+_USERS: dict[str, StoredUser] | None = None
+
+
+def _users() -> dict[str, StoredUser]:
+    global _USERS
+    if _USERS is None:
+        _USERS = _load_user_store()
+    return _USERS
+
+
+def authenticate(username: str, password: str) -> StoredUser | None:
+    user = _users().get(username)
+    if user is None:
+        return None
+    if not check_password_hash(user.password_hash, password):
+        return None
+    return user
+
+
+def current_user() -> dict | None:
+    if "username" not in session:
+        return None
+    return {"username": session["username"], "role": session.get("role", Role.GUEST.value)}
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        if "username" not in session:
+            _sec_log.info(
+                "AUTHZ_DENY reason=anonymous ip=%s path=%s method=%s",
+                request.remote_addr or "-", request.path, request.method,
+            )
+            return redirect(url_for("auth.login", next=request.full_path))
+        return view(*args, **kwargs)
+
+    return wrapper
+
+
+def role_required(*allowed: Role | str):
+    allowed_values = {r.value if isinstance(r, Role) else r for r in allowed}
+
+    def decorator(view):
+        @wraps(view)
+        def wrapper(*args, **kwargs):
+            user = current_user()
+            if user is None:
+                _sec_log.info(
+                    "AUTHZ_DENY reason=anonymous ip=%s path=%s method=%s",
+                    request.remote_addr or "-", request.path, request.method,
+                )
+                return redirect(url_for("auth.login", next=request.full_path))
+            if user["role"] not in allowed_values:
+                _sec_log.warning(
+                    "AUTHZ_DENY reason=role ip=%s user=%s role=%s required=%s path=%s",
+                    request.remote_addr or "-", user["username"], user["role"],
+                    sorted(allowed_values), request.path,
+                )
+                abort(403)
+            return view(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def login_user(user: StoredUser) -> None:
+    session.clear()
+    session["username"] = user.username
+    session["role"] = user.role.value
+    session.permanent = True
+    _auth_log.info("LOGIN_SUCCESS user=%s role=%s ip=%s",
+                   user.username, user.role.value, request.remote_addr or "-")
+
+
+def logout_user() -> None:
+    name = session.get("username", "-")
+    session.clear()
+    _auth_log.info("LOGOUT user=%s ip=%s", name, request.remote_addr or "-")
+
+
+def log_failed_login(username: str) -> None:
+    _auth_log.warning(
+        "LOGIN_FAILURE user=%s ip=%s",
+        username or "-", request.remote_addr or "-",
+    )
+
+
+__all__: Iterable[str] = (
+    "StoredUser",
+    "authenticate",
+    "current_user",
+    "login_required",
+    "role_required",
+    "login_user",
+    "logout_user",
+    "log_failed_login",
+)

--- a/presentations/services/credential_service.py
+++ b/presentations/services/credential_service.py
@@ -1,7 +1,0 @@
-from presentations.services.creadential import Credential, Role
-
-
-class CredentialService:
-    @staticmethod
-    def get_current_credential() -> Credential:
-        return Credential('superman', Role.ADMIN)

--- a/presentations/templates/base.html
+++ b/presentations/templates/base.html
@@ -40,9 +40,17 @@
                                         href="{{ url_for('plc.contact') }}">Contact</a></li>
 
             </ul>
-            <span class="navbar-text ms-auto">
-            user : {{ session.username or 'Guest' }} &nbsp; Role : {{ session.role or 'GUEST' }}
-          </span>
+            <div class="d-flex align-items-center ms-auto gap-3">
+                <span class="navbar-text">
+                    user : {{ session.username or 'Guest' }} &nbsp; Role : {{ session.role or 'GUEST' }}
+                </span>
+                {% if session.username %}
+                <form method="post" action="{{ url_for('auth.logout') }}" class="m-0">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-outline-light btn-sm">Logout</button>
+                </form>
+                {% endif %}
+            </div>
         </div>
 
     </div>

--- a/presentations/templates/login.html
+++ b/presentations/templates/login.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-5 col-lg-4">
+        <div class="card mt-5">
+            <div class="card-body">
+                <h3 class="card-title text-center mb-4">Sign in</h3>
+
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                {% for category, message in messages %}
+                <div class="alert alert-{{ 'danger' if category == 'error' else category }}" role="alert">
+                    {{ message }}
+                </div>
+                {% endfor %}
+                {% endwith %}
+
+                <form method="POST" action="{{ url_for('auth.login') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="username" class="form-label">Username</label>
+                        <input type="text" class="form-control" id="username" name="username" required autofocus>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="password" name="password" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Sign in</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pandas-stubs~=2.3.3",
     "plotly[all]>=6.4.0",
     "pyodbc>=5.3.0",
+    "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
     "reportlab>=4.4.6",
     "scikit-learn>=1.8.0",

--- a/scripts/hash_password.py
+++ b/scripts/hash_password.py
@@ -1,0 +1,31 @@
+"""Generate a werkzeug password hash for the auth user store.
+
+Usage:
+    python scripts/hash_password.py <username> <role>
+    (password is read from stdin, not echoed)
+
+Then put the printed JSON into AUTH_USERS_JSON or AUTH_USERS_FILE.
+"""
+import getpass
+import json
+import sys
+
+from werkzeug.security import generate_password_hash
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    username, role = sys.argv[1], sys.argv[2]
+    pw = getpass.getpass("Password: ")
+    pw2 = getpass.getpass("Confirm:  ")
+    if pw != pw2:
+        print("Passwords do not match.", file=sys.stderr)
+        return 1
+    print(json.dumps({username: {"password_hash": generate_password_hash(pw), "role": role}}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/users.json
+++ b/users.json
@@ -1,0 +1,10 @@
+{
+  "benoit": {
+    "password_hash": "scrypt:32768:8:1$TZ0VuCaFley2vDrh$edbf06aeabb4052f872f7e6aeb43bff53f75dbbd7c958b5898dd4b97051f01fd8354964ccad764c19e843edd7ae605025551af91376ddf9f71e8daa080a7e68f",
+    "role": "admin"
+  },
+  "tom": {
+    "password_hash": "scrypt:32768:8:1$QFBwA4SaTNGvhaX4$0d4fd177d35fbbc9876710bab52b9f620a51ca27e6b93dc3cf85dcacfa598ac23831eb4413fb77879810fb6bb3f7344c9eb94df1c445f7018949b08e0717926a",
+    "role": "admin"
+  }
+}


### PR DESCRIPTION
## Summary
Addresses **OWASP A02 — Cryptographic Failures / Sensitive Data Exposure** from `SECURITY_ASSESSMENT.md`.

- DB credentials now resolvable from `DB_*` env vars (overriding `config/Connection.yaml`); trust-server-certificate default flipped to `false`.
- `FLASK_SECRET_KEY` now loaded from env; production startup fails if missing; dev generates an ephemeral key with a warning instead of using the literal `"dev"`.
- `mail_service.py __main__` reads SMTP credentials from `SMTP_*` env vars.
- `.env.example` and `config/Connection.yaml.example` added.

## Test plan
- [ ] Set `FLASK_SECRET_KEY` and `DB_*` env vars locally, confirm app starts.
- [ ] Unset `FLASK_SECRET_KEY` with `FLASK_ENV=production`, confirm it raises.
- [ ] Confirm `config/Connection.yaml` (gitignored) still works for dev when env vars are unset.
- [ ] **Rotate** the previously-committed `sa / Test@1234` and SMTP credentials — they should be considered compromised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)