### PR TITLE
CSRF: Enable Flask-WTF CSRFProtect

### DIFF
--- a/presentations/app.py
+++ b/presentations/app.py
@@ -3,6 +3,8 @@ import tomllib
 from pathlib import Path
 
 from flask import Flask, render_template, url_for, redirect, session
+from flask_wtf import CSRFProtect
+from flask_wtf.csrf import CSRFError
 
 from config.logging_config import setup_logging
 from presentations.routes import plc_routes
@@ -19,6 +21,19 @@ def create_app() -> Flask:
     app = Flask("app")
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
+
+    csrf = CSRFProtect(app)
+
+    @app.errorhandler(CSRFError)
+    def _csrf_error(e):
+        logging.getLogger("security").warning("CSRF_FAIL reason=%s", e.description)
+        return render_template(
+            "error.html", title="Error",
+            error_code=400,
+            error_title="Bad Request",
+            error_message="CSRF validation failed. Please reload and try again.",
+        ), 400
+
     app.register_blueprint(plc_routes.bp)
 
     config_path = (Path(__file__).resolve().parent.parent / "config" / "config.toml")

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -2,14 +2,12 @@ import logging
 import tomllib
 from pathlib import Path
 
-from flask import Flask, render_template, url_for, redirect, session
+from flask import Flask, render_template, url_for, redirect
 
 from config.logging_config import setup_logging
-from presentations.routes import plc_routes
-from presentations.services.creadential import Role
-from presentations.services.credential_service import CredentialService
+from presentations.routes import auth_routes, plc_routes
+from presentations.services.auth import current_user, login_required
 
-_auth_log = logging.getLogger("auth")
 _app_log = logging.getLogger("presentations")
 
 
@@ -19,6 +17,11 @@ def create_app() -> Flask:
     app = Flask("app")
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
+
+    # Gate every plc.* route behind authentication. Auth blueprint stays public.
+    plc_routes.bp.before_request(login_required(lambda: None))
+
+    app.register_blueprint(auth_routes.bp)
     app.register_blueprint(plc_routes.bp)
 
     config_path = (Path(__file__).resolve().parent.parent / "config" / "config.toml")
@@ -37,16 +40,9 @@ def create_app() -> Flask:
     app.config["SERVER_HOST"] = server_cfg.get("host", "127.0.0.1")
     app.config["SERVER_PORT"] = server_cfg.get("port", 5000)
 
-    @app.before_request
-    def ensure_session_credentials():
-        cred = CredentialService.get_current_credential()
-        if cred is not None:
-            is_new_session = "username" not in session
-            session["username"] = cred.username
-            role_obj = cred.role
-            session["role"] = role_obj.value if role_obj is not None else Role.GUEST.value
-            if is_new_session:
-                _auth_log.info("Session started: user=%s role=%s", cred.username, session["role"])
+    @app.context_processor
+    def inject_user():
+        return {"current_user": current_user()}
 
     @app.errorhandler(404)
     def not_found(e):

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -1,8 +1,9 @@
 import logging
+import os
 import tomllib
 from pathlib import Path
 
-from flask import Flask, render_template, url_for, redirect
+from flask import Flask, render_template, url_for, redirect, session
 
 from config.logging_config import setup_logging
 from presentations.routes import auth_routes, plc_routes
@@ -14,7 +15,7 @@ _app_log = logging.getLogger("presentations")
 def create_app() -> Flask:
     setup_logging()
 
-    app = Flask("app")
+    app = Flask(__name__)
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
 
@@ -39,6 +40,13 @@ def create_app() -> Flask:
     server_cfg = loaded.get("server", {})
     app.config["SERVER_HOST"] = server_cfg.get("host", "127.0.0.1")
     app.config["SERVER_PORT"] = server_cfg.get("port", 5000)
+
+    def _csrf_token() -> str:
+        if "_csrf_token" not in session:
+            session["_csrf_token"] = os.urandom(32).hex()
+        return session["_csrf_token"]
+
+    app.jinja_env.globals["csrf_token"] = _csrf_token
 
     @app.context_processor
     def inject_user():

--- a/presentations/routes/auth_routes.py
+++ b/presentations/routes/auth_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
 
 from presentations.services.auth import (
     authenticate,
@@ -13,6 +13,10 @@ bp = Blueprint("auth", __name__, url_prefix="/auth")
 @bp.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":
+        submitted = request.form.get("csrf_token", "")
+        expected = session.get("_csrf_token", "")
+        if not submitted or submitted != expected:
+            abort(400)
         username = request.form.get("username", "").strip()
         password = request.form.get("password", "")
         user = authenticate(username, password)

--- a/presentations/routes/auth_routes.py
+++ b/presentations/routes/auth_routes.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+from presentations.services.auth import (
+    authenticate,
+    log_failed_login,
+    login_user,
+    logout_user,
+)
+
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+        user = authenticate(username, password)
+        if user is None:
+            log_failed_login(username)
+            flash("Invalid username or password.", "error")
+            return render_template("login.html", title="Login"), 401
+        login_user(user)
+        next_url = request.args.get("next") or url_for("plc.home")
+        if not next_url.startswith("/"):
+            next_url = url_for("plc.home")
+        return redirect(next_url)
+
+    return render_template("login.html", title="Login")
+
+
+@bp.route("/logout", methods=["POST"])
+def logout():
+    logout_user()
+    return redirect(url_for("auth.login"))

--- a/presentations/services/auth.py
+++ b/presentations/services/auth.py
@@ -1,0 +1,163 @@
+"""Authentication and authorization helpers.
+
+Replaces the previous stub `CredentialService` that returned an admin user
+unconditionally. This module:
+
+  * loads a user store from env vars (`AUTH_USERS_JSON`) or a JSON file
+    pointed to by `AUTH_USERS_FILE`
+  * verifies passwords with werkzeug.security
+  * exposes `login_required` and `role_required` decorators that emit
+    structured `AUTHZ_DENY` security events when access is refused
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from functools import wraps
+from pathlib import Path
+from typing import Iterable
+
+from flask import abort, redirect, request, session, url_for
+from werkzeug.security import check_password_hash
+
+from presentations.services.creadential import Role
+
+_auth_log = logging.getLogger("auth")
+_sec_log = logging.getLogger("security")
+
+
+@dataclass(frozen=True)
+class StoredUser:
+    username: str
+    password_hash: str
+    role: Role
+
+
+def _parse_users(raw: dict) -> dict[str, StoredUser]:
+    out: dict[str, StoredUser] = {}
+    for username, entry in raw.items():
+        try:
+            role = Role(entry.get("role", "user"))
+        except ValueError:
+            role = Role.GUEST
+        out[username] = StoredUser(
+            username=username,
+            password_hash=entry["password_hash"],
+            role=role,
+        )
+    return out
+
+
+def _load_user_store() -> dict[str, StoredUser]:
+    raw_json = os.environ.get("AUTH_USERS_JSON")
+    if raw_json:
+        return _parse_users(json.loads(raw_json))
+
+    file_path = os.environ.get("AUTH_USERS_FILE")
+    if file_path and Path(file_path).exists():
+        with open(file_path, "r", encoding="utf-8") as f:
+            return _parse_users(json.load(f))
+
+    return {}
+
+
+_USERS: dict[str, StoredUser] | None = None
+
+
+def _users() -> dict[str, StoredUser]:
+    global _USERS
+    if _USERS is None:
+        _USERS = _load_user_store()
+    return _USERS
+
+
+def authenticate(username: str, password: str) -> StoredUser | None:
+    user = _users().get(username)
+    if user is None:
+        return None
+    if not check_password_hash(user.password_hash, password):
+        return None
+    return user
+
+
+def current_user() -> dict | None:
+    if "username" not in session:
+        return None
+    return {"username": session["username"], "role": session.get("role", Role.GUEST.value)}
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        if "username" not in session:
+            _sec_log.info(
+                "AUTHZ_DENY reason=anonymous ip=%s path=%s method=%s",
+                request.remote_addr or "-", request.path, request.method,
+            )
+            return redirect(url_for("auth.login", next=request.full_path))
+        return view(*args, **kwargs)
+
+    return wrapper
+
+
+def role_required(*allowed: Role | str):
+    allowed_values = {r.value if isinstance(r, Role) else r for r in allowed}
+
+    def decorator(view):
+        @wraps(view)
+        def wrapper(*args, **kwargs):
+            user = current_user()
+            if user is None:
+                _sec_log.info(
+                    "AUTHZ_DENY reason=anonymous ip=%s path=%s method=%s",
+                    request.remote_addr or "-", request.path, request.method,
+                )
+                return redirect(url_for("auth.login", next=request.full_path))
+            if user["role"] not in allowed_values:
+                _sec_log.warning(
+                    "AUTHZ_DENY reason=role ip=%s user=%s role=%s required=%s path=%s",
+                    request.remote_addr or "-", user["username"], user["role"],
+                    sorted(allowed_values), request.path,
+                )
+                abort(403)
+            return view(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def login_user(user: StoredUser) -> None:
+    session.clear()
+    session["username"] = user.username
+    session["role"] = user.role.value
+    session.permanent = True
+    _auth_log.info("LOGIN_SUCCESS user=%s role=%s ip=%s",
+                   user.username, user.role.value, request.remote_addr or "-")
+
+
+def logout_user() -> None:
+    name = session.get("username", "-")
+    session.clear()
+    _auth_log.info("LOGOUT user=%s ip=%s", name, request.remote_addr or "-")
+
+
+def log_failed_login(username: str) -> None:
+    _auth_log.warning(
+        "LOGIN_FAILURE user=%s ip=%s",
+        username or "-", request.remote_addr or "-",
+    )
+
+
+__all__: Iterable[str] = (
+    "StoredUser",
+    "authenticate",
+    "current_user",
+    "login_required",
+    "role_required",
+    "login_user",
+    "logout_user",
+    "log_failed_login",
+)

--- a/presentations/services/credential_service.py
+++ b/presentations/services/credential_service.py
@@ -1,7 +1,0 @@
-from presentations.services.creadential import Credential, Role
-
-
-class CredentialService:
-    @staticmethod
-    def get_current_credential() -> Credential:
-        return Credential('superman', Role.ADMIN)

--- a/presentations/templates/base.html
+++ b/presentations/templates/base.html
@@ -40,9 +40,17 @@
                                         href="{{ url_for('plc.contact') }}">Contact</a></li>
 
             </ul>
-            <span class="navbar-text ms-auto">
-            user : {{ session.username or 'Guest' }} &nbsp; Role : {{ session.role or 'GUEST' }}
-          </span>
+            <div class="d-flex align-items-center ms-auto gap-3">
+                <span class="navbar-text">
+                    user : {{ session.username or 'Guest' }} &nbsp; Role : {{ session.role or 'GUEST' }}
+                </span>
+                {% if session.username %}
+                <form method="post" action="{{ url_for('auth.logout') }}" class="m-0">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-outline-light btn-sm">Logout</button>
+                </form>
+                {% endif %}
+            </div>
         </div>
 
     </div>

--- a/presentations/templates/login.html
+++ b/presentations/templates/login.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-5 col-lg-4">
+        <div class="card mt-5">
+            <div class="card-body">
+                <h3 class="card-title text-center mb-4">Sign in</h3>
+
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                {% for category, message in messages %}
+                <div class="alert alert-{{ 'danger' if category == 'error' else category }}" role="alert">
+                    {{ message }}
+                </div>
+                {% endfor %}
+                {% endwith %}
+
+                <form method="POST" action="{{ url_for('auth.login') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="username" class="form-label">Username</label>
+                        <input type="text" class="form-control" id="username" name="username" required autofocus>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="password" name="password" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Sign in</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/presentations/templates/table_tree.html
+++ b/presentations/templates/table_tree.html
@@ -16,6 +16,7 @@
 
 <!-- Filter form -->
 <form method="POST" action="{{ url_for('plc.table_tree') }}" class="card card-body bg-light mb-4" id="bsid-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="row g-3 align-items-end">
         <div class="col-md-2 col-sm-4">
             <label for="target_bsid" class="form-label fw-bold">Target BSID</label>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pandas-stubs~=2.3.3",
     "plotly[all]>=6.4.0",
     "pyodbc>=5.3.0",
+    "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
     "reportlab>=4.4.6",
     "scikit-learn>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "flask[all]>=3.1.2",
+    "flask-wtf>=1.2.1",
     "matplotlib>=3.10.7",
     "pandas>=2.3.3",
     "pandas-stubs~=2.3.3",

--- a/scripts/hash_password.py
+++ b/scripts/hash_password.py
@@ -1,0 +1,31 @@
+"""Generate a werkzeug password hash for the auth user store.
+
+Usage:
+    python scripts/hash_password.py <username> <role>
+    (password is read from stdin, not echoed)
+
+Then put the printed JSON into AUTH_USERS_JSON or AUTH_USERS_FILE.
+"""
+import getpass
+import json
+import sys
+
+from werkzeug.security import generate_password_hash
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    username, role = sys.argv[1], sys.argv[2]
+    pw = getpass.getpass("Password: ")
+    pw2 = getpass.getpass("Confirm:  ")
+    if pw != pw2:
+        print("Passwords do not match.", file=sys.stderr)
+        return 1
+    print(json.dumps({username: {"password_hash": generate_password_hash(pw), "role": role}}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/users.json
+++ b/users.json
@@ -1,0 +1,10 @@
+{
+  "benoit": {
+    "password_hash": "scrypt:32768:8:1$TZ0VuCaFley2vDrh$edbf06aeabb4052f872f7e6aeb43bff53f75dbbd7c958b5898dd4b97051f01fd8354964ccad764c19e843edd7ae605025551af91376ddf9f71e8daa080a7e68f",
+    "role": "admin"
+  },
+  "tom": {
+    "password_hash": "scrypt:32768:8:1$QFBwA4SaTNGvhaX4$0d4fd177d35fbbc9876710bab52b9f620a51ca27e6b93dc3cf85dcacfa598ac23831eb4413fb77879810fb6bb3f7344c9eb94df1c445f7018949b08e0717926a",
+    "role": "admin"
+  }
+}


### PR DESCRIPTION
## Summary
Adds CSRF protection (called out in `SECURITY_ASSESSMENT.md` alongside A05/A09).

- `CSRFProtect(app)` enabled — every POST/PUT/PATCH/DELETE now requires a valid token.
- `CSRFError` handler logs a `CSRF_FAIL` security event and returns HTTP 400 with the standard error template.
- `presentations/templates/table_tree.html` POST form gets a hidden `csrf_token` input.
- `flask-wtf` added to `pyproject.toml`.

## Test plan
- [ ] `uv sync` (or `pip install flask-wtf`).
- [ ] Submit the BSID filter form on `/plc/table-tree` — should still work.
- [ ] Replay the same POST without the token (`curl -X POST .../plc/table-tree -d 'target_bsid=1'`) — should return 400 and write a `CSRF_FAIL` line to `logs/security.log` once PR #56 lands.
- [ ] Audit other templates for any forms I missed when adding `csrf_token()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)