### PR TITLE
A01/A07: Real authentication scaffold (replaces admin stub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Regeltechniekers, lijnverantwoordelijken, productiebedienden bij Arcelor die CIM
 - **Database:** SQL Server via SQLAlchemy + pyodbc
 - **Charts:** Plotly (interactieve grafieken, server-side gerenderd als HTML)
 - **Rapporten:** PDF-export vanuit de Table Tree pagina
-- **Run-omgeving:** IIS (Windows), security via IIS user-identificatie
+- **Run-omgeving:** IIS (Windows), authenticatie via Flask sessie + gehashte wachtwoorden
 - **Frontend:** Jinja2 templates, Bootstrap 5
 
 ## 5. Architectuur
@@ -131,6 +131,8 @@ flask --app app run --debug
 - [Diagrams pagina](docs/diagrams_page.md) – opbouw, spinner, selectieboxen, dataflow
 - [Table Tree pagina](docs/table_tree_page.md) – flow, boomstructuur, JavaScript, validatie
 - [Projectverloop](docs/project_verloop.md) – tijdlijn, Gantt chart, bereikte doelen per fase
+- [Security](SECURITY.md) – authenticatie, autorisatie, CSRF, wachtwoordhashing, logging
+- [Auth setup](docs/auth_setup.md) – branch uitrollen, gebruikers aanmaken, omgevingsvariabelen
 
 ## Structure
 ![Project Structure](docs/ProjectStructureDiagram.png)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,125 @@
+# Security
+
+Dit document beschrijft hoe authenticatie en autorisatie werken in de First Faults GUI applicatie.
+
+## Overzicht
+
+De applicatie gebruikt een op Flask gebaseerde sessie-authenticatie met de volgende lagen:
+
+```
+Browser → Login (CSRF check) → Wachtwoordverificatie → Sessie → Beschermde routes
+```
+
+## Authenticatie (A01 / A07)
+
+### Gebruikersopslag
+
+Gebruikers worden geladen vanuit een van deze twee bronnen (in volgorde van prioriteit):
+
+| Omgevingsvariabele | Beschrijving |
+|--------------------|--------------|
+| `AUTH_USERS_JSON`  | JSON-blob direct als string |
+| `AUTH_USERS_FILE`  | Pad naar een JSON-bestand |
+
+Als geen van beide is ingesteld, kan **niemand inloggen**. Elke beschermde route stuurt dan door naar `/auth/login`.
+
+### Wachtwoordhashing
+
+Wachtwoorden worden nooit in plaintext opgeslagen. De applicatie gebruikt **Werkzeug's `scrypt`-gebaseerde hashing** (`scrypt:32768:8:1$...`). Verificatie gebeurt via `check_password_hash()`.
+
+Nieuw wachtwoordhash genereren:
+
+```bash
+python scripts/hash_password.py <gebruikersnaam> <rol>
+```
+
+Het script vraagt het wachtwoord interactief (niet zichtbaar), vraagt om bevestiging, en drukt een JSON-fragment af dat je in `users.json` kunt plakken.
+
+### Rollen
+
+Gedefinieerd in `presentations/services/creadential.py`:
+
+| Rol       | Beschrijving                     |
+|-----------|----------------------------------|
+| `admin`   | Volledige toegang                |
+| `user`    | Standaard gebruiker              |
+| `guest`   | Beperkte toegang                 |
+| `anonymous` | Niet ingelogd (intern gebruik) |
+
+### Login-flow
+
+1. `GET /auth/login` — toont het loginformulier met een CSRF-token in de sessie.
+2. `POST /auth/login` — controleert CSRF-token, daarna gebruikersnaam/wachtwoord.
+3. Bij succes: `session.clear()` gevolgd door een nieuwe sessie met `username` en `role`.
+4. Redirect naar de oorspronkelijk opgevraagde URL (of `plc.home`).
+
+### Logout
+
+`POST /auth/logout` — wist de volledige sessie en stuurt terug naar de loginpagina. Logout via GET is niet mogelijk (bescherming tegen CSRF-aanvallen via links).
+
+## Autorisatie
+
+### `login_required`
+
+Toegepast op het volledige `plc.*` blueprint via `before_request` in `presentations/app.py`:
+
+```python
+plc_routes.bp.before_request(login_required(lambda: None))
+```
+
+Niet-ingelogde gebruikers worden doorgestuurd naar `/auth/login?next=<pad>`.
+
+### `role_required(*rollen)`
+
+Decorator voor routes die een specifieke rol vereisen:
+
+```python
+@role_required(Role.ADMIN)
+def admin_only_view():
+    ...
+```
+
+Bij onvoldoende rechten: HTTP 403.
+
+## CSRF-bescherming
+
+Het CSRF-token wordt aangemaakt via `os.urandom(32).hex()` en opgeslagen in de Flask-sessie. Bij elk POST-verzoek op de loginroute wordt het token uit het formulier vergeleken met het token in de sessie.
+
+Het token is beschikbaar in Jinja2-templates via:
+
+```html
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+```
+
+**Alle nieuwe POST-formulieren moeten dit veld bevatten.**
+
+## Sessie-instellingen
+
+- `app.secret_key` staat momenteel op `"dev"` (hardcoded). **Vervang dit in productie:**
+
+```python
+app.secret_key = os.environ["FLASK_SECRET_KEY"]
+```
+
+Genereer een sterke sleutel:
+
+```bash
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+## Logging
+
+Beveiligingsgebeurtenissen worden gelogd via twee aparte loggers:
+
+| Logger     | Gebeurtenissen                                              |
+|------------|-------------------------------------------------------------|
+| `auth`     | `LOGIN_SUCCESS`, `LOGIN_FAILURE`, `LOGOUT`                  |
+| `security` | `AUTHZ_DENY reason=anonymous`, `AUTHZ_DENY reason=role`     |
+
+Elke log-entry bevat het IP-adres, gebruikersnaam, en het gevraagde pad.
+
+## Wat NIET doen
+
+- `users.json` met echte wachtwoordhashes **niet committen** in git. Gebruik `AUTH_USERS_FILE` buiten de repo of een secret manager.
+- De `"dev"` secret key **niet gebruiken** in productie of gedeelde omgevingen.
+- CSRF-token **niet weglaten** bij nieuwe POST-formulieren.

--- a/docs/auth_setup.md
+++ b/docs/auth_setup.md
@@ -1,0 +1,111 @@
+# Enabling the auth scaffold from `security/a01-a07-auth-scaffold`
+
+This branch replaces the stub `CredentialService` (which always returned an
+admin user) with a real authentication layer: hashed passwords, a login/logout
+flow, CSRF on the login form, and `login_required` / `role_required`
+decorators. To use it on your machine you need to do a few things beyond just
+checking out the branch.
+
+## 1. Check out the branch and sync dependencies
+
+```bash
+git fetch origin
+git checkout security/a01-a07-auth-scaffold
+git pull
+```
+
+A new runtime dependency was added in `pyproject.toml`
+(`werkzeug` is pulled in via `flask[all]`, but the password hashing helper is
+new code that uses it). Re-sync your environment:
+
+```bash
+uv sync          # or: pip install -e .
+```
+
+## 2. Provide a user store
+
+The app loads users from one of two environment variables (checked in order):
+
+1. `AUTH_USERS_JSON` — a JSON blob inline.
+2. `AUTH_USERS_FILE` — path to a JSON file.
+
+If neither is set, **no user can log in** and every protected page will
+redirect to `/auth/login`.
+
+The repo ships an example file at `users.json` in the project root. To use it:
+
+```bash
+export AUTH_USERS_FILE="$PWD/users.json"
+```
+
+The shipped `users.json` contains demo accounts (`benoit`, `tom`). Treat those
+hashes as throwaway — generate your own before doing anything real.
+
+## 3. Generate your own password hashes
+
+```bash
+python scripts/hash_password.py <username> <role>
+```
+
+The script prompts for a password (not echoed), confirms it, and prints a
+JSON fragment like:
+
+```json
+{
+  "alice": {
+    "password_hash": "scrypt:32768:8:1$...",
+    "role": "admin"
+  }
+}
+```
+
+Drop the fragment(s) into your `users.json` (or concatenate into
+`AUTH_USERS_JSON`). Valid roles come from `presentations/services/creadential.py`
+(`Role` enum) — typically `admin`, `user`, `guest`.
+
+## 4. Set a real `SECRET_KEY` (recommended)
+
+`presentations/app.py` currently hardcodes `app.secret_key = "dev"`. Sessions
+and the CSRF token both depend on this key, so for any non-local use replace
+it with an env-driven value, e.g.:
+
+```python
+app.secret_key = os.environ["FLASK_SECRET_KEY"]
+```
+
+and export `FLASK_SECRET_KEY` to a long random string. For local dev the
+default `"dev"` works but invalidates sessions on restart.
+
+## 5. Run the app
+
+```bash
+export AUTH_USERS_FILE="$PWD/users.json"
+# optional: export FLASK_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+python -m presentations.app    # or however you normally launch it
+```
+
+Then visit `http://127.0.0.1:5000/`. You will be redirected to
+`/auth/login`. After a successful login you land on `plc.home`. The navbar
+gains a logout link (POST to `/auth/logout`).
+
+## 6. Verifying it works
+
+- Hitting any `plc.*` route while logged out → 302 to `/auth/login`.
+- Wrong password → flash message + HTTP 401, with a `LOGIN_FAILURE` line in
+  the `auth` logger.
+- Successful login → `LOGIN_SUCCESS` log line, session cookie set.
+- Logout → session cleared, `LOGOUT` log line.
+- Denied access on a `role_required` route → `AUTHZ_DENY reason=role ...`
+  in the `security` logger and HTTP 403.
+
+## 7. Things to watch out for when merging downstream
+
+- Any code still importing `CredentialService` for its old "always admin"
+  behaviour will break — that shortcut is gone. Use `current_user()` from
+  `presentations.services.auth` instead.
+- The login form submits a `csrf_token` field; if you build other POST
+  forms, include `{{ csrf_token() }}` and validate it the same way
+  `auth_routes.login` does.
+- `users.json` is committed for demo purposes. Do **not** commit a file
+  containing real credentials — point `AUTH_USERS_FILE` at something
+  outside the repo, or use `AUTH_USERS_JSON` from your secret manager.

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -2,14 +2,12 @@ import logging
 import tomllib
 from pathlib import Path
 
-from flask import Flask, render_template, url_for, redirect, session
+from flask import Flask, render_template, url_for, redirect
 
 from config.logging_config import setup_logging
-from presentations.routes import plc_routes
-from presentations.services.creadential import Role
-from presentations.services.credential_service import CredentialService
+from presentations.routes import auth_routes, plc_routes
+from presentations.services.auth import current_user, login_required
 
-_auth_log = logging.getLogger("auth")
 _app_log = logging.getLogger("presentations")
 
 
@@ -19,6 +17,11 @@ def create_app() -> Flask:
     app = Flask("app")
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
+
+    # Gate every plc.* route behind authentication. Auth blueprint stays public.
+    plc_routes.bp.before_request(login_required(lambda: None))
+
+    app.register_blueprint(auth_routes.bp)
     app.register_blueprint(plc_routes.bp)
 
     config_path = (Path(__file__).resolve().parent.parent / "config" / "config.toml")
@@ -37,16 +40,9 @@ def create_app() -> Flask:
     app.config["SERVER_HOST"] = server_cfg.get("host", "127.0.0.1")
     app.config["SERVER_PORT"] = server_cfg.get("port", 5000)
 
-    @app.before_request
-    def ensure_session_credentials():
-        cred = CredentialService.get_current_credential()
-        if cred is not None:
-            is_new_session = "username" not in session
-            session["username"] = cred.username
-            role_obj = cred.role
-            session["role"] = role_obj.value if role_obj is not None else Role.GUEST.value
-            if is_new_session:
-                _auth_log.info("Session started: user=%s role=%s", cred.username, session["role"])
+    @app.context_processor
+    def inject_user():
+        return {"current_user": current_user()}
 
     @app.errorhandler(404)
     def not_found(e):

--- a/presentations/app.py
+++ b/presentations/app.py
@@ -1,8 +1,9 @@
 import logging
+import os
 import tomllib
 from pathlib import Path
 
-from flask import Flask, render_template, url_for, redirect
+from flask import Flask, render_template, url_for, redirect, session
 
 from config.logging_config import setup_logging
 from presentations.routes import auth_routes, plc_routes
@@ -14,7 +15,7 @@ _app_log = logging.getLogger("presentations")
 def create_app() -> Flask:
     setup_logging()
 
-    app = Flask("app")
+    app = Flask(__name__)
     app.secret_key = "dev"
     app.jinja_options["autoescape"] = True
 
@@ -39,6 +40,13 @@ def create_app() -> Flask:
     server_cfg = loaded.get("server", {})
     app.config["SERVER_HOST"] = server_cfg.get("host", "127.0.0.1")
     app.config["SERVER_PORT"] = server_cfg.get("port", 5000)
+
+    def _csrf_token() -> str:
+        if "_csrf_token" not in session:
+            session["_csrf_token"] = os.urandom(32).hex()
+        return session["_csrf_token"]
+
+    app.jinja_env.globals["csrf_token"] = _csrf_token
 
     @app.context_processor
     def inject_user():

--- a/presentations/routes/auth_routes.py
+++ b/presentations/routes/auth_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
 
 from presentations.services.auth import (
     authenticate,
@@ -13,6 +13,10 @@ bp = Blueprint("auth", __name__, url_prefix="/auth")
 @bp.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":
+        submitted = request.form.get("csrf_token", "")
+        expected = session.get("_csrf_token", "")
+        if not submitted or submitted != expected:
+            abort(400)
         username = request.form.get("username", "").strip()
         password = request.form.get("password", "")
         user = authenticate(username, password)

--- a/presentations/routes/auth_routes.py
+++ b/presentations/routes/auth_routes.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+from presentations.services.auth import (
+    authenticate,
+    log_failed_login,
+    login_user,
+    logout_user,
+)
+
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+        user = authenticate(username, password)
+        if user is None:
+            log_failed_login(username)
+            flash("Invalid username or password.", "error")
+            return render_template("login.html", title="Login"), 401
+        login_user(user)
+        next_url = request.args.get("next") or url_for("plc.home")
+        if not next_url.startswith("/"):
+            next_url = url_for("plc.home")
+        return redirect(next_url)
+
+    return render_template("login.html", title="Login")
+
+
+@bp.route("/logout", methods=["POST"])
+def logout():
+    logout_user()
+    return redirect(url_for("auth.login"))

--- a/presentations/services/auth.py
+++ b/presentations/services/auth.py
@@ -1,0 +1,163 @@
+"""Authentication and authorization helpers.
+
+Replaces the previous stub `CredentialService` that returned an admin user
+unconditionally. This module:
+
+  * loads a user store from env vars (`AUTH_USERS_JSON`) or a JSON file
+    pointed to by `AUTH_USERS_FILE`
+  * verifies passwords with werkzeug.security
+  * exposes `login_required` and `role_required` decorators that emit
+    structured `AUTHZ_DENY` security events when access is refused
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from functools import wraps
+from pathlib import Path
+from typing import Iterable
+
+from flask import abort, redirect, request, session, url_for
+from werkzeug.security import check_password_hash
+
+from presentations.services.creadential import Role
+
+_auth_log = logging.getLogger("auth")
+_sec_log = logging.getLogger("security")
+
+
+@dataclass(frozen=True)
+class StoredUser:
+    username: str
+    password_hash: str
+    role: Role
+
+
+def _parse_users(raw: dict) -> dict[str, StoredUser]:
+    out: dict[str, StoredUser] = {}
+    for username, entry in raw.items():
+        try:
+            role = Role(entry.get("role", "user"))
+        except ValueError:
+            role = Role.GUEST
+        out[username] = StoredUser(
+            username=username,
+            password_hash=entry["password_hash"],
+            role=role,
+        )
+    return out
+
+
+def _load_user_store() -> dict[str, StoredUser]:
+    raw_json = os.environ.get("AUTH_USERS_JSON")
+    if raw_json:
+        return _parse_users(json.loads(raw_json))
+
+    file_path = os.environ.get("AUTH_USERS_FILE")
+    if file_path and Path(file_path).exists():
+        with open(file_path, "r", encoding="utf-8") as f:
+            return _parse_users(json.load(f))
+
+    return {}
+
+
+_USERS: dict[str, StoredUser] | None = None
+
+
+def _users() -> dict[str, StoredUser]:
+    global _USERS
+    if _USERS is None:
+        _USERS = _load_user_store()
+    return _USERS
+
+
+def authenticate(username: str, password: str) -> StoredUser | None:
+    user = _users().get(username)
+    if user is None:
+        return None
+    if not check_password_hash(user.password_hash, password):
+        return None
+    return user
+
+
+def current_user() -> dict | None:
+    if "username" not in session:
+        return None
+    return {"username": session["username"], "role": session.get("role", Role.GUEST.value)}
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        if "username" not in session:
+            _sec_log.info(
+                "AUTHZ_DENY reason=anonymous ip=%s path=%s method=%s",
+                request.remote_addr or "-", request.path, request.method,
+            )
+            return redirect(url_for("auth.login", next=request.full_path))
+        return view(*args, **kwargs)
+
+    return wrapper
+
+
+def role_required(*allowed: Role | str):
+    allowed_values = {r.value if isinstance(r, Role) else r for r in allowed}
+
+    def decorator(view):
+        @wraps(view)
+        def wrapper(*args, **kwargs):
+            user = current_user()
+            if user is None:
+                _sec_log.info(
+                    "AUTHZ_DENY reason=anonymous ip=%s path=%s method=%s",
+                    request.remote_addr or "-", request.path, request.method,
+                )
+                return redirect(url_for("auth.login", next=request.full_path))
+            if user["role"] not in allowed_values:
+                _sec_log.warning(
+                    "AUTHZ_DENY reason=role ip=%s user=%s role=%s required=%s path=%s",
+                    request.remote_addr or "-", user["username"], user["role"],
+                    sorted(allowed_values), request.path,
+                )
+                abort(403)
+            return view(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def login_user(user: StoredUser) -> None:
+    session.clear()
+    session["username"] = user.username
+    session["role"] = user.role.value
+    session.permanent = True
+    _auth_log.info("LOGIN_SUCCESS user=%s role=%s ip=%s",
+                   user.username, user.role.value, request.remote_addr or "-")
+
+
+def logout_user() -> None:
+    name = session.get("username", "-")
+    session.clear()
+    _auth_log.info("LOGOUT user=%s ip=%s", name, request.remote_addr or "-")
+
+
+def log_failed_login(username: str) -> None:
+    _auth_log.warning(
+        "LOGIN_FAILURE user=%s ip=%s",
+        username or "-", request.remote_addr or "-",
+    )
+
+
+__all__: Iterable[str] = (
+    "StoredUser",
+    "authenticate",
+    "current_user",
+    "login_required",
+    "role_required",
+    "login_user",
+    "logout_user",
+    "log_failed_login",
+)

--- a/presentations/services/credential_service.py
+++ b/presentations/services/credential_service.py
@@ -1,7 +1,0 @@
-from presentations.services.creadential import Credential, Role
-
-
-class CredentialService:
-    @staticmethod
-    def get_current_credential() -> Credential:
-        return Credential('superman', Role.ADMIN)

--- a/presentations/templates/base.html
+++ b/presentations/templates/base.html
@@ -40,9 +40,17 @@
                                         href="{{ url_for('plc.contact') }}">Contact</a></li>
 
             </ul>
-            <span class="navbar-text ms-auto">
-            user : {{ session.username or 'Guest' }} &nbsp; Role : {{ session.role or 'GUEST' }}
-          </span>
+            <div class="d-flex align-items-center ms-auto gap-3">
+                <span class="navbar-text">
+                    user : {{ session.username or 'Guest' }} &nbsp; Role : {{ session.role or 'GUEST' }}
+                </span>
+                {% if session.username %}
+                <form method="post" action="{{ url_for('auth.logout') }}" class="m-0">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-outline-light btn-sm">Logout</button>
+                </form>
+                {% endif %}
+            </div>
         </div>
 
     </div>

--- a/presentations/templates/login.html
+++ b/presentations/templates/login.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-5 col-lg-4">
+        <div class="card mt-5">
+            <div class="card-body">
+                <h3 class="card-title text-center mb-4">Sign in</h3>
+
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                {% for category, message in messages %}
+                <div class="alert alert-{{ 'danger' if category == 'error' else category }}" role="alert">
+                    {{ message }}
+                </div>
+                {% endfor %}
+                {% endwith %}
+
+                <form method="POST" action="{{ url_for('auth.login') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="username" class="form-label">Username</label>
+                        <input type="text" class="form-control" id="username" name="username" required autofocus>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="password" name="password" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Sign in</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pandas-stubs~=2.3.3",
     "plotly[all]>=6.4.0",
     "pyodbc>=5.3.0",
+    "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
     "reportlab>=4.4.6",
     "scikit-learn>=1.8.0",

--- a/scripts/hash_password.py
+++ b/scripts/hash_password.py
@@ -1,0 +1,31 @@
+"""Generate a werkzeug password hash for the auth user store.
+
+Usage:
+    python scripts/hash_password.py <username> <role>
+    (password is read from stdin, not echoed)
+
+Then put the printed JSON into AUTH_USERS_JSON or AUTH_USERS_FILE.
+"""
+import getpass
+import json
+import sys
+
+from werkzeug.security import generate_password_hash
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    username, role = sys.argv[1], sys.argv[2]
+    pw = getpass.getpass("Password: ")
+    pw2 = getpass.getpass("Confirm:  ")
+    if pw != pw2:
+        print("Passwords do not match.", file=sys.stderr)
+        return 1
+    print(json.dumps({username: {"password_hash": generate_password_hash(pw), "role": role}}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/users.json
+++ b/users.json
@@ -6,5 +6,11 @@
   "tom": {
     "password_hash": "scrypt:32768:8:1$QFBwA4SaTNGvhaX4$0d4fd177d35fbbc9876710bab52b9f620a51ca27e6b93dc3cf85dcacfa598ac23831eb4413fb77879810fb6bb3f7344c9eb94df1c445f7018949b08e0717926a",
     "role": "admin"
+  },
+
+  "ben": {
+    "password_hash": "scrypt:32768:8:1$8WvVcUfVlQW4EteT$864f44ad3a608e09e2c16a38041fe2cc7d267b2a3bb831e77975588782e15cdddd8d67a50d5fb161ca960bd8cb07c8aaec000de105dd1dfde510b4d3405a7e8e",
+    "role": "admin"
   }
+
 }

--- a/users.json
+++ b/users.json
@@ -1,0 +1,10 @@
+{
+  "benoit": {
+    "password_hash": "scrypt:32768:8:1$TZ0VuCaFley2vDrh$edbf06aeabb4052f872f7e6aeb43bff53f75dbbd7c958b5898dd4b97051f01fd8354964ccad764c19e843edd7ae605025551af91376ddf9f71e8daa080a7e68f",
+    "role": "admin"
+  },
+  "tom": {
+    "password_hash": "scrypt:32768:8:1$QFBwA4SaTNGvhaX4$0d4fd177d35fbbc9876710bab52b9f620a51ca27e6b93dc3cf85dcacfa598ac23831eb4413fb77879810fb6bb3f7344c9eb94df1c445f7018949b08e0717926a",
+    "role": "admin"
+  }
+}


### PR DESCRIPTION
## Summary
Addresses **OWASP A01 — Broken Access Control** and **A07 — Identification & Authentication Failures** from `SECURITY_ASSESSMENT.md`. The previous \`CredentialService\` returned \`Credential('superman', Role.ADMIN)\` for everyone; this PR replaces that with a real, gated flow.

### What changed
- **\`presentations/services/auth.py\`** — user store loaded from \`AUTH_USERS_JSON\` env var or \`AUTH_USERS_FILE\` JSON file; password verification via \`werkzeug.security.check_password_hash\`; \`login_required\` / \`role_required\` decorators that emit structured \`AUTHZ_DENY\` events to the security logger.
- **\`presentations/routes/auth_routes.py\`** — \`GET/POST /auth/login\` (with open-redirect-safe \`next\`) and \`POST /auth/logout\`.
- **\`presentations/templates/login.html\`** — login form with CSRF token.
- **\`presentations/app.py\`** — gates every \`plc.*\` route behind \`login_required\` via a blueprint \`before_request\`; registers the new auth blueprint; drops the stub session-priming hook and dead \`CredentialService\` imports.
- **\`presentations/services/credential_service.py\`** — removed.
- **\`scripts/hash_password.py\`** — CLI to mint password hashes for the user store.

### Setup (deployer's responsibility)
\`\`\`bash
# generate a hash
python scripts/hash_password.py admin admin

# run the app with the user store in env
export AUTH_USERS_JSON='{"admin": {"password_hash": "scrypt:...", "role": "admin"}}'
export FLASK_SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')
\`\`\`

Until \`AUTH_USERS_JSON\`/\`AUTH_USERS_FILE\` is set the app will reject every \`/plc/*\` request with a redirect to \`/auth/login\` and login will always fail — that is intentional fail-closed behaviour.

## Depends on
- This PR adds CSRF tokens to its own \`login.html\`, but the global CSRFProtect lives in #57. Merge order: #57 → this.
- \`AUTHZ_DENY\` and \`LOGIN_*\` events go to the \`security\` / \`auth\` loggers introduced in #56.

## Test plan
- [ ] With \`AUTH_USERS_JSON\` set, \`GET /plc/\` redirects to \`/auth/login\`.
- [ ] Valid login redirects to \`/plc/\` and the session is established.
- [ ] Invalid login renders \`login.html\` with HTTP 401 and writes a \`LOGIN_FAILURE\` line to \`auth.log\`.
- [ ] \`POST /auth/logout\` clears the session and writes \`LOGOUT\` to \`auth.log\`.
- [ ] \`role_required(Role.ADMIN)\` on a route returns 403 + writes \`AUTHZ_DENY reason=role …\` to \`security.log\` for non-admins.

## Out of scope (follow-ups)
- Account lockout / rate limiting on \`/auth/login\`.
- Session inactivity timeout.
- Password policy.
- Move user store into the existing SQL Server DB.
- MFA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)